### PR TITLE
CORS instructions added as a new page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## AWS IoT TwinMkaker Documentation
+## AWS IoT TwinMaker Documentation
 
 The open source version of the AWS IoT TwinMaker Documentation. You can submit feedback & requests for changes by submitting issues in this repo.
 To view a complete list of topics covered in this guide, see this repo's index [index](doc_source/index.md).

--- a/doc_source/cors-configuration-grafana.md
+++ b/doc_source/cors-configuration-grafana.md
@@ -1,0 +1,46 @@
+--------
+
+--------
+
+# CORS Configuration for Grafana scene viewer<a name="cors-configuration-grafana"></a>
+
+AWS IoT TwinMaker Grafana plugin requires a proper CORS (Cross-origin resource sharing) configuration that allows the Grafana user interface to load resources from the Amazon S3 bucket. Without the CORS configuration, you will receive an error message as "Load 3D Scene failed with Network Failure" on the Scene viewer since the Grafana domain couldn't access the resources in the Amazon S3 bucket.
+
+For the CORS configuration of the Amazon S3 bucket, 
+
+1. Sign in to the AWS Management Console and open the Amazon S3 console at [https://console\.aws\.amazon\.com/s3/](https://console.aws.amazon.com/s3/)\.
+
+1. In the **Buckets** list, choose the name of the bucket that you use as your TwinMaker workspace's resource bucket\.
+
+1. Choose **Permissions**\.
+
+1. In the **Cross\-origin resource sharing \(CORS\)** section, choose **Edit**\.
+
+1. In the **CORS configuration editor** text box, type or copy and paste the following JSON CORS configuration by replacing the Grafana workspace domain `<GRAFANA-WORKSPACE-DOMAIN>` with yours e.g. `g-1234567890.grafana-workspace.REGION.amazonaws.com`\. Please note that you keep the asterisk `*` character at the beginning.
+
+```
+[
+    {
+        "AllowedHeaders": [
+            "*"
+        ],
+        "AllowedMethods": [
+            "GET",
+            "PUT",
+            "POST",
+            "DELETE",
+            "HEAD"
+        ],
+        "AllowedOrigins": [
+            "*<GRAFANA-WORKSPACE-DOMAIN>"
+        ],
+        "ExposeHeaders": [
+            "ETag"
+        ]
+    }
+]
+```
+
+1. Choose **Save changes**\.
+
+For more information about configuring CORS for Amazon S3 buckets, see [Using cross-origin resource sharing (CORS)]([grafana-environment.md](https://docs.aws.amazon.com/AmazonS3/latest/userguide/cors.html))\.

--- a/doc_source/cors-configuration-grafana.md
+++ b/doc_source/cors-configuration-grafana.md
@@ -43,4 +43,4 @@ For the CORS configuration of the Amazon S3 bucket,
 
 1. Choose **Save changes**\.
 
-For more information about configuring CORS for Amazon S3 buckets, see [Using cross-origin resource sharing (CORS)]([grafana-environment.md](https://docs.aws.amazon.com/AmazonS3/latest/userguide/cors.html))\.
+For more information about configuring CORS for Amazon S3 buckets, see [Using cross-origin resource sharing (CORS)](https://docs.aws.amazon.com/AmazonS3/latest/userguide/cors.html)\.

--- a/doc_source/grafana-environment.md
+++ b/doc_source/grafana-environment.md
@@ -9,3 +9,5 @@ You can use Amazon Managed Grafana for a fully managed service, or set up a Graf
 For more information about both Grafana environment options, see the following topics:
 + [Amazon Managed Grafana](amazon-managed-grafana.md)
 + [Self\-managed Grafana](self-managed-grafana.md)
+
+Also, you'll need to modify CORS configuration of the Amazon S3 bucket for allowing the Grafana user interface to load resources from the bucket. For the instructions, see [CORS Configuration for Grafana scene viewer](cors-configuration-grafana.md)\. 

--- a/doc_source/index.md
+++ b/doc_source/index.md
@@ -38,6 +38,7 @@ Amazon's trademarks and trade dress may not be used in
    + [Setting up your Grafana environment](grafana-environment.md)
       + [Amazon Managed Grafana](amazon-managed-grafana.md)
       + [Self-managed Grafana](self-managed-grafana.md)
+   + [CORS Configuration for Grafana scene viewer](cors-configuration-grafana.md)
    + [Creating a dashboard IAM role](dashboard-IAM-role.md)
    + [Creating an AWS IoT TwinMaker video player policy](tm-video-policy.md)
 + [AWS IoT TwinMaker video integration](video-integration.md)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
AWS IoT TwinMaker Grafana plugin's Scene viewer panel requires a proper CORS configuration on the Amazon S3 bucket to allow the Grafana user interface to load resources from the bucket. This instruction was missing on the documentation. The absence of this part leads a friction for getting started with the service. Also, it requires an online search to fix the CORS issue that appears as an error message as "Load 3D Scene failed with Network Failure". So, the instructions should be a part of the documentation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
